### PR TITLE
Added method to find files without reloading

### DIFF
--- a/lib/Config/ZOMG.pm
+++ b/lib/Config/ZOMG.pm
@@ -16,7 +16,7 @@ has package => (
 
 has source => (
    is => 'rw',
-   handles => [qw/ driver local_suffix no_env env_lookup path found /],
+   handles => [qw/ driver local_suffix no_env env_lookup path found find /],
 );
 
 has load_once => (
@@ -281,6 +281,13 @@ times without incurring any loading-time penalty
 Returns a list of files found
 
 If the list is empty then no files were loaded/read
+
+=head2 find
+
+  $config->find
+
+Returns a list of files that configuration will be loaded from. Use this method
+to check whether configuration files have changed, without actually reloading.
 
 =head2 clone
 

--- a/lib/Config/ZOMG/Source/Loader.pm
+++ b/lib/Config/ZOMG/Source/Loader.pm
@@ -110,6 +110,11 @@ sub found {
     return @{ $self->_found };
 }
 
+sub find {
+    my $self = shift;
+    return grep { -f $_ } $self->_find_files;
+}
+
 sub _load_files {
     my $self = shift;
     my $files = shift;

--- a/t/17-found.t
+++ b/t/17-found.t
@@ -21,6 +21,7 @@ sub has_Config_General {
 
 {
     my $config = Config::ZOMG->new( qw{ name xyzzy path t/assets } );
+    cmp_deeply( [ $config->find ], bag( 't/assets/xyzzy.pl', 't/assets/xyzzy_local.pl' ) );
     ok( $config->load );
     ok( keys %{ $config->load } );
     ok( $config->found );


### PR DESCRIPTION
This is just a tiny modification to provide a documented method for checking whether configuration files have changed (path changed, new files, files removed...). This is required to support reloading if configuration files in Iong-running applications only if needed. I hesitated to add support of `reload( $seconds )` which would compare first `find` and `found` and second the modification time of files returned by `found` - what do you think?
