### PR TITLE
modify 'found' to only return what has already been read

### DIFF
--- a/lib/Config/ZOMG.pm
+++ b/lib/Config/ZOMG.pm
@@ -95,8 +95,9 @@ sub open {
     }
     my $self = shift;
     warn "You called ->open on an instantiated object with arguments" if @_;
+    my $config_hash = $self->load;
     return unless $self->found;
-    return wantarray ? ($self->load, $self) : $self->load;
+    return wantarray ? ($config_hash, $self) : $config_hash;
 }
 
 sub load {

--- a/lib/Config/ZOMG/Source/Loader.pm
+++ b/lib/Config/ZOMG/Source/Loader.pm
@@ -105,9 +105,7 @@ sub read {
 
 sub found {
     my $self = shift;
-    $self->read unless $self->_found;
-
-    return @{ $self->_found };
+    return ( $self->_found ? @{ $self->_found } : () );
 }
 
 sub find {

--- a/t/17-found.t
+++ b/t/17-found.t
@@ -39,7 +39,7 @@ sub has_Config_General {
 {
     my $config = Config::ZOMG->new( file => 't/assets/some_random_file.pl', quiet_deprecation => 1 );
 
-    ok( $config->found ); # Do ->read via ->found
+    ok( !$config->found ); # Don't do ->read via ->found
     ok( $config->load );
     ok( keys %{ $config->load } );
     cmp_deeply( [ $config->found ], bag( 't/assets/some_random_file.pl' ) );


### PR DESCRIPTION
As already included and described in https://github.com/frioux/Config-ZOMG/pull/2 - I removed the Reloader stuff (published independently as [Config::Reload](https://metacpan.org/module/Config::Reload)) and cleaned git history for a new pull request or discussion.
